### PR TITLE
Peg ruamel.yaml version at 0.12.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
         'six',
         'attrs >= 15.0.0',
         'requests >= 2.3.0',
-        'ruamel.yaml',
+        'ruamel.yaml == 0.12.6',
     ]
     py2_requires = install_requires + [
         'enum34 >= 1.1.0',


### PR DESCRIPTION
Changes since version 0.12.6 cause `ruamel.yaml.load()` to hang.
